### PR TITLE
Allow running without generation of ansible_fact vars

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,17 +16,17 @@
 - name: Gather variables for each operating system
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+    - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}.yml"
+    - "{{ ansible_facts['os_family'] | lower }}.yml"
   tags:
     - always
 
 - include: resolvconf-apt.yml
   when:
-    - ansible_pkg_mgr == 'apt'
+    - ansible_facts['pkg_mgr'] == 'apt'
 
 
 - name: Update resolvers


### PR DESCRIPTION
Since newer OpenStack releases no longer generate ansible_<variable> fact vars, they must now be accessed via ansible_facts['variable'] (see https://docs.openstack.org/releasenotes/openstack-ansible/2023.1.html#relnotes-27-0-0-unmaintained-2023-1-upgrade-notes), which this PR implements.